### PR TITLE
feat(poem.txt): replace redundant line-terminating rhyme

### DIFF
--- a/src/poem.txt
+++ b/src/poem.txt
@@ -24,7 +24,7 @@ Version control, its dance, in rhythms that grow.
 Branches twirl gracefully, like dancers in flight,
 Commits pirouette, each adding their light.
 Merge conflicts tango, resolving their spree,
-In the grand ballet of collaborative spree.
+In the grand ballet of collaborative glee.
 
 History unfolds in a graceful arc,
 As repositories hum, a versioned park.


### PR DESCRIPTION
This commit replaces 'spree' ending line 27 (and also ending the preceding line 28) with an appropriate alternative rhyme.